### PR TITLE
Add support for ZeroSSL account registration

### DIFF
--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -157,6 +157,10 @@ func register(ctx *cli.Context, client *lego.Client) (*registration.Resource, er
 		log.Fatal("You did not accept the TOS. Unable to proceed.")
 	}
 
+	if ctx.String("server") == lego.ZeroSSLDirectory {
+		return client.Registration.RegisterWithZeroSSL(registration.RegisterOptions{TermsOfServiceAgreed: true})
+	}
+
 	if ctx.Bool("eab") {
 		kid := ctx.String("kid")
 		hmacEncoded := ctx.String("hmac")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -52,7 +52,7 @@ func newClient(ctx *cli.Context, acc registration.User, keyType certcrypto.KeyTy
 		log.Fatalf("Could not create client: %v", err)
 	}
 
-	if client.GetExternalAccountRequired() && !ctx.IsSet("eab") {
+	if client.GetExternalAccountRequired() && !ctx.IsSet("eab") && config.CADirURL != lego.ZeroSSLDirectory {
 		log.Fatal("Server requires External Account Binding. Use --eab with --kid and --hmac.")
 	}
 

--- a/lego/client_config.go
+++ b/lego/client_config.go
@@ -38,6 +38,9 @@ const (
 
 	// LEDirectoryStaging URL to the Let's Encrypt staging.
 	LEDirectoryStaging = "https://acme-staging-v02.api.letsencrypt.org/directory"
+
+	// ZeroSSLDirectory URL to the ZeroSSL production.
+	ZeroSSLDirectory = "https://acme.zerossl.com/v2/DV90"
 )
 
 type Config struct {


### PR DESCRIPTION
This commit extends lego library and cli tool to support issuing certificates from ZeroSSL without having to manually create an account.

Without this commit ZeroSSL can be used but users need to manually create ZeroSSL account and start `lego` in EAB (External Account Binding) mode.

From the `lego` cli tool perspective this commit:

Detects if `lego` ir running with ZeroSSL ACME directory `--server https://acme.zerossl.com/v2/DV90` and uses ZeroSSL API to issue keys for EAB. There is no need to provide `--eab`, `--kid`, `--hmac` values anymore.

From the library perspective this commit:

Creates new method `RegisterWithZeroSSL()` in the `registration` package which takes care of creating ZeroSSL account with a given email. Internally it re-uses `RegisterWithExternalAccountBinding()` method after KID and HMAC are retrieved from ZeroSSL registration endpoint.